### PR TITLE
Specobject importer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,3 @@
+language: java
+jdk:
+  - oraclejdk8

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,7 @@
 language: java
 jdk:
   - oraclejdk8
+
+cache:
+  directories:
+  - $HOME/.m2

--- a/launch/Openfasttrack - Run all tests.launch
+++ b/launch/Openfasttrack - Run all tests.launch
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.eclipse.jdt.junit.launchconfig">
+<listAttribute key="StepOutExcludePkgsOrClasses"/>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_PATHS">
+<listEntry value="/openfasttrack/src/test/java"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.core.MAPPED_RESOURCE_TYPES">
+<listEntry value="2"/>
+</listAttribute>
+<listAttribute key="org.eclipse.debug.ui.favoriteGroups">
+<listEntry value="org.eclipse.debug.ui.launchGroup.run"/>
+</listAttribute>
+<stringAttribute key="org.eclipse.jdt.junit.CONTAINER" value="=openfasttrack/src\/test\/java"/>
+<booleanAttribute key="org.eclipse.jdt.junit.KEEPRUNNING_ATTR" value="false"/>
+<stringAttribute key="org.eclipse.jdt.junit.TESTNAME" value=""/>
+<stringAttribute key="org.eclipse.jdt.junit.TEST_KIND" value="org.eclipse.jdt.junit.loader.junit4"/>
+<booleanAttribute key="org.eclipse.jdt.launching.ATTR_USE_START_ON_FIRST_THREAD" value="true"/>
+<stringAttribute key="org.eclipse.jdt.launching.CLASSPATH_PROVIDER" value="org.eclipse.m2e.launchconfig.classpathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.MAIN_TYPE" value=""/>
+<stringAttribute key="org.eclipse.jdt.launching.PROJECT_ATTR" value="openfasttrack"/>
+<stringAttribute key="org.eclipse.jdt.launching.SOURCE_PATH_PROVIDER" value="org.eclipse.m2e.launchconfig.sourcepathProvider"/>
+<stringAttribute key="org.eclipse.jdt.launching.VM_ARGUMENTS" value="-Djava.util.logging.config.file=src/test/resources/logging.properties"/>
+</launchConfiguration>

--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,16 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.19.1</version>
+				<configuration>
+					<systemPropertyVariables>
+						<java.util.logging.config.file>${basedir}/src/test/resources/logging.properties</java.util.logging.config.file>
+					</systemPropertyVariables>
+				</configuration>
+			</plugin>
 		</plugins>
 	</build>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,9 @@
 			<scope>test</scope>
 		</dependency>
 	</dependencies>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
 	<build>
 		<plugins>
 			<plugin>

--- a/src/main/java/openfasttrack/core/SpecificationItem.java
+++ b/src/main/java/openfasttrack/core/SpecificationItem.java
@@ -65,7 +65,7 @@ public class SpecificationItem
 
     public static class Builder
     {
-        private final SpecificationItemId id;
+        private SpecificationItemId id;
         private String description;
         private String rationale;
         private String comment;
@@ -73,15 +73,21 @@ public class SpecificationItem
         private final List<SpecificationItemId> dependOnIds;
         private final List<String> neededArtifactTypes;
 
-        public Builder(final SpecificationItemId id)
+        public Builder()
         {
-            this.id = id;
+            this.id = null;
             this.description = "";
             this.rationale = "";
             this.comment = "";
             this.coveredIds = new ArrayList<>();
             this.dependOnIds = new ArrayList<>();
             this.neededArtifactTypes = new ArrayList<>();
+        }
+
+        public Builder id(final SpecificationItemId id)
+        {
+            this.id = id;
+            return this;
         }
 
         public Builder description(final String description)
@@ -122,6 +128,10 @@ public class SpecificationItem
 
         public SpecificationItem build()
         {
+            if (this.id == null)
+            {
+                throw new IllegalStateException("No id given");
+            }
             return new SpecificationItem(this.id, this.description, this.rationale, this.comment,
                     this.coveredIds, this.dependOnIds, this.neededArtifactTypes);
         }

--- a/src/main/java/openfasttrack/core/SpecificationItemId.java
+++ b/src/main/java/openfasttrack/core/SpecificationItemId.java
@@ -136,12 +136,56 @@ public class SpecificationItemId
             this.id = id;
         }
 
+        public Builder()
+        {
+            this(null);
+        }
+
+        public Builder artifactType(final String artifactType)
+        {
+            this.artifactType = artifactType;
+            return this;
+        }
+
+        public Builder name(final String name)
+        {
+            this.name = name;
+            return this;
+        }
+
+        public Builder revision(final int revision)
+        {
+            this.revision = revision;
+            return this;
+        }
+
         /**
          * Build a specification item ID
          *
          * @return the ID
          */
         public SpecificationItemId build()
+        {
+            if (this.id == null)
+            {
+                validateFields();
+            } else
+            {
+                parseId();
+            }
+
+            return new SpecificationItemId(this.name, this.artifactType, this.revision);
+        }
+
+        private void validateFields()
+        {
+            if (this.name == null || this.artifactType == null)
+            {
+                throw new IllegalStateException("Name or artifactType is missing");
+            }
+        }
+
+        private void parseId()
         {
             final Matcher matcher = this.idPattern.matcher(this.id);
             if (matcher.matches())
@@ -151,11 +195,9 @@ public class SpecificationItemId
                 this.revision = Integer.parseInt(matcher.group(3));
             } else
             {
-                throw new IllegalStateException(
-                        "Sting \"" + this.id + "\" cannot be parsed to a specification item ID");
+                throw new IllegalStateException("Sting \"" + this.id
+                        + "\" cannot be parsed to a specification item ID");
             }
-
-            return new SpecificationItemId(this.name, this.artifactType, this.revision);
         }
     }
 

--- a/src/main/java/openfasttrack/importer/ImportEventListener.java
+++ b/src/main/java/openfasttrack/importer/ImportEventListener.java
@@ -11,12 +11,19 @@ import openfasttrack.core.SpecificationItemId;
 public interface ImportEventListener
 {
     /**
-     * The importer found a new specification item ID
+     * The importer found a new specification item. The
+     * {@link SpecificationItemId} must be defined using
+     * {@link #setId(SpecificationItemId)}.
+     */
+    public void foundNewSpecificationItem();
+
+    /**
+     * The importer found the ID of the specification item
      *
      * @param id
      *            the ID of the new item
      */
-    public void foundNewSpecificationItem(final SpecificationItemId id);
+    public void setId(final SpecificationItemId id);
 
     /**
      * Append a text block to an item description

--- a/src/main/java/openfasttrack/importer/ImporterException.java
+++ b/src/main/java/openfasttrack/importer/ImporterException.java
@@ -1,0 +1,16 @@
+package openfasttrack.importer;
+
+public class ImporterException extends RuntimeException
+{
+    private static final long serialVersionUID = 1L;
+
+    public ImporterException(final String message, final Throwable cause)
+    {
+        super(message, cause);
+    }
+
+    public ImporterException(final String message)
+    {
+        super(message);
+    }
+}

--- a/src/main/java/openfasttrack/importer/SpecificationItemListBuilder.java
+++ b/src/main/java/openfasttrack/importer/SpecificationItemListBuilder.java
@@ -19,13 +19,13 @@ public class SpecificationItemListBuilder implements ImportEventListener
     private StringBuilder comment = new StringBuilder();
 
     @Override
-    public void foundNewSpecificationItem(final SpecificationItemId id)
+    public void foundNewSpecificationItem()
     {
         if (this.itemBuilder != null)
         {
             createNewSpecificationItem();
         }
-        this.itemBuilder = new SpecificationItem.Builder(id);
+        this.itemBuilder = new SpecificationItem.Builder();
     }
 
     private void createNewSpecificationItem()
@@ -44,6 +44,12 @@ public class SpecificationItemListBuilder implements ImportEventListener
         this.description = new StringBuilder();
         this.rationale = new StringBuilder();
         this.comment = new StringBuilder();
+    }
+
+    @Override
+    public void setId(final SpecificationItemId id)
+    {
+        this.itemBuilder.id(id);
     }
 
     @Override

--- a/src/main/java/openfasttrack/importer/markdown/MarkdownImporter.java
+++ b/src/main/java/openfasttrack/importer/markdown/MarkdownImporter.java
@@ -152,7 +152,8 @@ public class MarkdownImporter implements Importer
     {
         final String idText = this.stateMachine.getLastToken();
         final SpecificationItemId id = new SpecificationItemId.Builder(idText).build();
-        this.listener.foundNewSpecificationItem(id);
+        this.listener.foundNewSpecificationItem();
+        this.listener.setId(id);
     }
 
     private void addCoverage()

--- a/src/main/java/openfasttrack/importer/specobject/ImportHelper.java
+++ b/src/main/java/openfasttrack/importer/specobject/ImportHelper.java
@@ -1,0 +1,40 @@
+package openfasttrack.importer.specobject;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.XMLEvent;
+
+import openfasttrack.core.SpecificationItem;
+
+class ImportHelper
+{
+    private final static Logger LOG = Logger.getLogger(ImportHelper.class.getName());
+    private final XMLEventReader xmlEventReader;
+    private final List<SpecificationItem> items;
+
+    private XMLEvent currentEvent;
+
+    public ImportHelper(final XMLEventReader xmlEventReader)
+    {
+        this.xmlEventReader = xmlEventReader;
+        this.items = new ArrayList<>();
+    }
+
+    void runImport() throws XMLStreamException
+    {
+        while (this.xmlEventReader.hasNext())
+        {
+            this.currentEvent = this.xmlEventReader.nextEvent();
+            LOG.finest(() -> "Event: " + this.currentEvent);
+        }
+    }
+
+    public List<SpecificationItem> getItems()
+    {
+        return this.items;
+    }
+}

--- a/src/main/java/openfasttrack/importer/specobject/ImportHelper.java
+++ b/src/main/java/openfasttrack/importer/specobject/ImportHelper.java
@@ -1,40 +1,68 @@
 package openfasttrack.importer.specobject;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.logging.Logger;
 
+import javax.xml.namespace.QName;
 import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamConstants;
 import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.Attribute;
+import javax.xml.stream.events.StartElement;
 import javax.xml.stream.events.XMLEvent;
 
-import openfasttrack.core.SpecificationItem;
+import openfasttrack.importer.ImportEventListener;
 
 class ImportHelper
 {
     private final static Logger LOG = Logger.getLogger(ImportHelper.class.getName());
     private final XMLEventReader xmlEventReader;
-    private final List<SpecificationItem> items;
+    private final ImportEventListener listener;
+    private String defaultDoctype;
 
-    private XMLEvent currentEvent;
-
-    public ImportHelper(final XMLEventReader xmlEventReader)
+    public ImportHelper(final XMLEventReader xmlEventReader, final ImportEventListener listener)
     {
         this.xmlEventReader = xmlEventReader;
-        this.items = new ArrayList<>();
+        this.listener = listener;
     }
 
     void runImport() throws XMLStreamException
     {
         while (this.xmlEventReader.hasNext())
         {
-            this.currentEvent = this.xmlEventReader.nextEvent();
-            LOG.finest(() -> "Event: " + this.currentEvent);
+            final XMLEvent currentEvent = this.xmlEventReader.nextEvent();
+            switch (currentEvent.getEventType())
+            {
+            case XMLStreamConstants.START_ELEMENT:
+                foundStartElement(currentEvent.asStartElement());
+                break;
+
+            default:
+                LOG.finest(() -> "Event: " + currentEvent);
+                break;
+            }
         }
     }
 
-    public List<SpecificationItem> getItems()
+    private void foundStartElement(final StartElement element) throws XMLStreamException
     {
-        return this.items;
+        switch (element.getName().getLocalPart())
+        {
+        case "specobjects":
+            final Attribute doctypeAttribute = element.getAttributeByName(new QName("doctype"));
+            if (doctypeAttribute != null)
+            {
+                this.defaultDoctype = doctypeAttribute.getValue();
+                LOG.finest(() -> "Found specobjects with doctype " + this.defaultDoctype);
+            }
+            break;
+        case "specobject":
+            new SingleSpecobjectImportHelper(this.xmlEventReader, this.listener,
+                    this.defaultDoctype).runImport();
+            break;
+
+        default:
+            LOG.warning(() -> "Found unknown start element " + element.getName());
+            break;
+        }
     }
 }

--- a/src/main/java/openfasttrack/importer/specobject/SingleSpecobjectImportHelper.java
+++ b/src/main/java/openfasttrack/importer/specobject/SingleSpecobjectImportHelper.java
@@ -1,0 +1,95 @@
+package openfasttrack.importer.specobject;
+
+import java.util.logging.Logger;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.events.StartElement;
+import javax.xml.stream.events.XMLEvent;
+
+import openfasttrack.core.SpecificationItemId;
+import openfasttrack.core.SpecificationItemId.Builder;
+import openfasttrack.importer.ImportEventListener;
+import openfasttrack.importer.ImporterException;
+
+class SingleSpecobjectImportHelper
+{
+    private final static Logger LOG = Logger
+            .getLogger(SingleSpecobjectImportHelper.class.getName());
+    private final XMLEventReader xmlEventReader;
+    private final ImportEventListener listener;
+    private final Builder idBuilder;
+
+    public SingleSpecobjectImportHelper(final XMLEventReader xmlEventReader,
+            final ImportEventListener listener, final String defaultDoctype)
+    {
+        this.idBuilder = new SpecificationItemId.Builder() //
+                .artifactType(defaultDoctype);
+        this.xmlEventReader = xmlEventReader;
+        this.listener = listener;
+    }
+
+    void runImport() throws XMLStreamException
+    {
+        this.listener.foundNewSpecificationItem();
+        while (this.xmlEventReader.hasNext())
+        {
+            final XMLEvent currentEvent = this.xmlEventReader.nextEvent();
+            switch (currentEvent.getEventType())
+            {
+            case XMLStreamConstants.START_ELEMENT:
+                foundStartElement(currentEvent.asStartElement());
+                break;
+            case XMLStreamConstants.END_ELEMENT:
+                if (currentEvent.asEndElement().getName().getLocalPart().equals("specobject"))
+                {
+                    final SpecificationItemId id = this.idBuilder.build();
+                    LOG.fine(() -> "Specobject element closed: build id " + id);
+                    this.listener.setId(id);
+                    return;
+                }
+            default:
+                LOG.warning(() -> "Ignore event " + currentEvent);
+                break;
+            }
+        }
+    }
+
+    private void foundStartElement(final StartElement element) throws XMLStreamException
+    {
+        switch (element.getName().getLocalPart())
+        {
+        case "id":
+            final String id = readCharacterData(element);
+            LOG.fine(() -> "Found spec object id " + id);
+            this.idBuilder.name(id);
+            break;
+        case "version":
+            final int version = readIntCharacterData(element);
+            LOG.fine(() -> "Found spec object version " + version);
+            this.idBuilder.revision(version);
+            break;
+
+        default:
+            LOG.warning(() -> "Found unknown start element " + element.getName());
+            break;
+        }
+    }
+
+    private int readIntCharacterData(final StartElement element)
+            throws NumberFormatException, XMLStreamException
+    {
+        return Integer.parseInt(readCharacterData(element));
+    }
+
+    private String readCharacterData(final StartElement element) throws XMLStreamException
+    {
+        final XMLEvent characterEvent = this.xmlEventReader.peek();
+        if (characterEvent == null || !characterEvent.isCharacters())
+        {
+            throw new ImporterException("No character data found for element " + element);
+        }
+        return characterEvent.asCharacters().getData();
+    }
+}

--- a/src/main/java/openfasttrack/importer/specobject/SpecobjectImporter.java
+++ b/src/main/java/openfasttrack/importer/specobject/SpecobjectImporter.java
@@ -1,0 +1,43 @@
+package openfasttrack.importer.specobject;
+
+import java.io.BufferedReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.logging.Logger;
+
+import javax.xml.stream.XMLEventReader;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamException;
+
+import openfasttrack.core.SpecificationItem;
+import openfasttrack.importer.Importer;
+import openfasttrack.importer.ImporterException;
+
+public class SpecobjectImporter implements Importer
+{
+    private final static Logger LOG = Logger.getLogger(SpecobjectImporter.class.getName());
+    private final XMLInputFactory xmlInputFactory;
+    private final Reader reader;
+
+    public SpecobjectImporter(final Reader reader, final XMLInputFactory xmlInputFactory)
+    {
+        this.xmlInputFactory = xmlInputFactory;
+        this.reader = new BufferedReader(reader);
+    }
+
+    @Override
+    public List<SpecificationItem> runImport()
+    {
+        try
+        {
+            final XMLEventReader xmlEventReader = this.xmlInputFactory
+                    .createXMLEventReader(this.reader);
+            final ImportHelper importHelper = new ImportHelper(xmlEventReader);
+            importHelper.runImport();
+            return importHelper.getItems();
+        } catch (final XMLStreamException e)
+        {
+            throw new ImporterException("Error importing specobjects document", e);
+        }
+    }
+}

--- a/src/main/java/openfasttrack/importer/specobject/SpecobjectImporter.java
+++ b/src/main/java/openfasttrack/importer/specobject/SpecobjectImporter.java
@@ -12,6 +12,7 @@ import javax.xml.stream.XMLStreamException;
 import openfasttrack.core.SpecificationItem;
 import openfasttrack.importer.Importer;
 import openfasttrack.importer.ImporterException;
+import openfasttrack.importer.SpecificationItemListBuilder;
 
 public class SpecobjectImporter implements Importer
 {
@@ -32,9 +33,10 @@ public class SpecobjectImporter implements Importer
         {
             final XMLEventReader xmlEventReader = this.xmlInputFactory
                     .createXMLEventReader(this.reader);
-            final ImportHelper importHelper = new ImportHelper(xmlEventReader);
+            final SpecificationItemListBuilder specItemListBuilder = new SpecificationItemListBuilder();
+            final ImportHelper importHelper = new ImportHelper(xmlEventReader, specItemListBuilder);
             importHelper.runImport();
-            return importHelper.getItems();
+            return specItemListBuilder.build();
         } catch (final XMLStreamException e)
         {
             throw new ImporterException("Error importing specobjects document", e);

--- a/src/test/java/openfasttrack/core/TestSpecificationItem.java
+++ b/src/test/java/openfasttrack/core/TestSpecificationItem.java
@@ -37,7 +37,7 @@ public class TestSpecificationItem
 
     private SpecificationItem.Builder createSimpleItem()
     {
-        final SpecificationItem.Builder builder = new SpecificationItem.Builder(ID);
+        final SpecificationItem.Builder builder = new SpecificationItem.Builder().id(ID);
         builder.description(DESCRIPTION).rationale(RATIONALE).comment(COMMENT);
         return builder;
     }

--- a/src/test/java/openfasttrack/importer/TestSpecificationItemListBuilder.java
+++ b/src/test/java/openfasttrack/importer/TestSpecificationItemListBuilder.java
@@ -19,12 +19,12 @@ public class TestSpecificationItemListBuilder
     public void testBuildBasicItem()
     {
         final SpecificationItemListBuilder itemsBuilder = new SpecificationItemListBuilder();
-        itemsBuilder.foundNewSpecificationItem(ID);
+        itemsBuilder.foundNewSpecificationItem();
+        itemsBuilder.setId(ID);
         itemsBuilder.appendDescription(DESCRIPTION);
         final List<SpecificationItem> items = itemsBuilder.build();
         assertThat(items.size(), equalTo(1));
         assertThat(items.get(0).getId(), equalTo(ID));
         assertThat(items.get(0).getDescription(), equalTo(DESCRIPTION));
     }
-
 }

--- a/src/test/java/openfasttrack/importer/markdown/TestImportMarkdown.java
+++ b/src/test/java/openfasttrack/importer/markdown/TestImportMarkdown.java
@@ -1,11 +1,13 @@
 package openfasttrack.importer.markdown;
 
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.verify;
 
 import java.io.StringReader;
 
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -42,7 +44,10 @@ public class TestImportMarkdown
         new ImporterFactory();
         final Importer importer = ImporterFactory.createImporter(reader, this.listenerMock);
         importer.runImport();
-        verify(this.listenerMock).foundNewSpecificationItem(ID);
+        final InOrder inOrder = inOrder(this.listenerMock);
+        inOrder.verify(this.listenerMock).foundNewSpecificationItem();
+        inOrder.verify(this.listenerMock).setId(ID);
+        inOrder.verifyNoMoreInteractions();
     }
 
     // @Test

--- a/src/test/java/openfasttrack/importer/specobject/SpecobjectImporterTest.java
+++ b/src/test/java/openfasttrack/importer/specobject/SpecobjectImporterTest.java
@@ -10,7 +10,6 @@ import java.util.List;
 import javax.xml.stream.XMLInputFactory;
 
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import openfasttrack.core.SpecificationItem;
@@ -30,7 +29,7 @@ public class SpecobjectImporterTest
     }
 
     @Test
-    @Ignore
+    // @Ignore
     public void test() throws FileNotFoundException
     {
         final List<SpecificationItem> result = runImporter("single-specobject.xml");

--- a/src/test/java/openfasttrack/importer/specobject/SpecobjectImporterTest.java
+++ b/src/test/java/openfasttrack/importer/specobject/SpecobjectImporterTest.java
@@ -1,0 +1,46 @@
+package openfasttrack.importer.specobject;
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.util.List;
+
+import javax.xml.stream.XMLInputFactory;
+
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import openfasttrack.core.SpecificationItem;
+
+/**
+ * Test for {@link SpecobjectImporter}
+ */
+public class SpecobjectImporterTest
+{
+    private static final String TEST_FILE_PREFIX = "src/test/resources/specobject/";
+    private XMLInputFactory xmlInputFactory;
+
+    @Before
+    public void setUp()
+    {
+        this.xmlInputFactory = XMLInputFactory.newFactory();
+    }
+
+    @Test
+    @Ignore
+    public void test() throws FileNotFoundException
+    {
+        final List<SpecificationItem> result = runImporter("single-specobject.xml");
+        assertThat(result, hasSize(1));
+    }
+
+    private List<SpecificationItem> runImporter(final String fileName) throws FileNotFoundException
+    {
+        final FileReader reader = new FileReader(TEST_FILE_PREFIX + fileName);
+        final SpecobjectImporter importer = new SpecobjectImporter(reader, this.xmlInputFactory);
+        return importer.runImport();
+    }
+}

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,8 @@
+handlers = java.util.logging.ConsoleHandler
+.level = INFO
+java.util.logging.ConsoleHandler.level = FINEST
+java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
+java.util.logging.ConsoleHandler.encoding = UTF-8
+java.util.logging.SimpleFormatter.format = %1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS %1$Tp %2$s%n%4$s: %5$s%6$s%n
+
+openfasttrack.importer.specobject.level = FINEST

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -3,6 +3,6 @@ handlers = java.util.logging.ConsoleHandler
 java.util.logging.ConsoleHandler.level = FINEST
 java.util.logging.ConsoleHandler.formatter = java.util.logging.SimpleFormatter
 java.util.logging.ConsoleHandler.encoding = UTF-8
-java.util.logging.SimpleFormatter.format = %1$tb %1$td, %1$tY %1$tl:%1$tM:%1$tS %1$Tp %2$s%n%4$s: %5$s%6$s%n
+java.util.logging.SimpleFormatter.format = %1$tF %1$tT [%4$s] %2$s - %5$s %6$s%n
 
 openfasttrack.importer.specobject.level = FINEST

--- a/src/test/resources/specobject/single-specobject.xml
+++ b/src/test/resources/specobject/single-specobject.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<specobjects doctype="doctype">
+	<specobject>
+		<id>id</id>
+		<version>1</version>
+		<description>
+			Description
+		</description>
+		<rationale>
+			Rationale
+		</rationale>
+		<comment>
+			Comment
+		</comment>
+		<needscoverage>
+			<needsobj>code</needsobj>
+			<needsobj>test</needsobj>
+		</needscoverage>
+		<providescoverage>
+			<provcov>
+				<linksto>provid</linksto>
+				<dstversion>provvers</dstversion>
+			</provcov>
+		</providescoverage>
+	</specobject>
+</specobjects>
+  


### PR DESCRIPTION
Refactoring of `SpecificationItemListBuilder`: all specifying id after foundNewSpecificationItem() was called. This allows composing the id from name, revision and doctype.